### PR TITLE
Fix an error not found toml plugin

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -1,9 +1,14 @@
 <idea-plugin url="https://github.com/koxudaxi/poetry-pycharm-plugin">
     <id>com.koxudaxi.poetry</id>
     <name>Poetry</name>
-    <version>0.0.8</version>
+    <version>0.0.9</version>
     <vendor email="koaxudai@gmail.com">Koudai Aono @koxudaxi</vendor>
     <change-notes><![CDATA[
+    <h2>version 0.0.9</h2>
+    <p>Bug fixes</p>
+    <ul>
+        <li>Fix an error not found toml plugin [#42] </li>
+    </ul>
     <h2>version 0.0.8</h2>
     <p>Features</p>
     <ul>

--- a/src/com/koxudaxi/poetry/PoetryExtrasLineMarkerContributor.kt
+++ b/src/com/koxudaxi/poetry/PoetryExtrasLineMarkerContributor.kt
@@ -11,7 +11,11 @@ object PoetryExtrasLineMarkerContributor : RunLineMarkerContributor() {
     override fun getInfo(element: PsiElement): Info? {
         val sdk = element.project.pythonSdk ?: return null
         if (!isPoetry(element.project, sdk)) return null
-        if (element !is TomlKey) return null
+        try {
+            if (element !is TomlKey) return null
+        } catch (e: NoClassDefFoundError) {
+            return null //Toml plugin is installed. But, PyCharm has not restarted yet.
+        }
         val keyValue = element.parent as? TomlKeyValue ?: return null
         val names = (keyValue.parent as? TomlTable)?.header?.names ?: return null
         if (names.joinToString(".") { it.text } != "tool.poetry.extras") return null


### PR DESCRIPTION
This PR fixes an error.
The Toml plugin is installed. But, PyCharm has not restarted yet.