### PR TITLE
Create new windows interpreter

### DIFF
--- a/src/com/koxudaxi/poetry/poetry.kt
+++ b/src/com/koxudaxi/poetry/poetry.kt
@@ -256,7 +256,7 @@ fun runPoetry(projectPath: @SystemDependent String, vararg args: String): String
             exitCode != 0 ->
                 throw PyExecutionException("Error Running Poetry", executable, args.asList(),
                         stdout, stderr, exitCode, emptyList())
-            else -> stdout
+            else -> stdout.trim()
         }
     }
 }


### PR DESCRIPTION
This fixes #52 
After debugging it looks like the poetry output had a trailing \n on it so when strings got made they were not valid and could not be found. Adding a simple trim call to the output resolved all problems and a new interpreter can now be made.