### PR TITLE
improved build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,9 @@ intellij {
     plugins "java", "Kotlin", "PythonCore:$python_core_version", "org.toml.lang:$toml_version"
     alternativeIdePath "/opt/JetBrains/pycharm-community-2020.1" // Change with the path to your IntelliJ CE installation directory
 
+patchPluginXml{
+    sinceBuild "201.*"
+    untilBuild "202.*"
 }
 
 allprojects {

--- a/build.gradle
+++ b/build.gradle
@@ -26,9 +26,10 @@ intellij {
     updateSinceUntilBuild false
     downloadSources true
     plugins "java", "Kotlin", "PythonCore:$python_core_version", "org.toml.lang:$toml_version"
-    alternativeIdePath "/opt/JetBrains/pycharm-community-2020.1" // Change with the path to your IntelliJ CE installation directory
+    alternativeIdePath "/Applications/IntelliJ IDEA CE.app/Contents" // Change with the path to your IntelliJ CE installation directory
+}
 
-patchPluginXml{
+patchPluginXml {
     sinceBuild "201.*"
     untilBuild "202.*"
 }
@@ -61,7 +62,7 @@ allprojects {
     dependencies {
         testImplementation 'junit:junit:4.13'
         implementation "org.apache.tuweni:tuweni-toml:$tuweni_toml_version"
-        compile 'org.jetbrains:annotations:20.0.0'
+        compile "org.jetbrains:annotations:20.0.0"
     }
 
     jacocoTestReport {

--- a/build.gradle
+++ b/build.gradle
@@ -1,15 +1,17 @@
 buildscript {
     ext.kotlin_version = "1.4.0"
-    ext.python_core_version = "201.6668.115"
-    ext.toml_version = "0.2.120.37-193"
+    ext.python_core_version = "202.6397.124"
+    ext.toml_version = "0.2.128.3278-202"
+    ext.tuweni_toml_version = "1.1.0"
+    ext.jvm_version = "11"
+    ext.language_version = "1.4"
     repositories {
         mavenCentral()
     }
     dependencies {
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version", "org.apache.tuweni:tuweni-toml:1.1.0"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version", "org.apache.tuweni:tuweni-toml:$tuweni_toml_version"
     }
 }
-
 
 plugins {
     id "org.jetbrains.intellij" version "0.4.21"
@@ -19,12 +21,12 @@ plugins {
 
 intellij {
     pluginName project.name
-    version "2020.1"
+    version "2020.2"
     type "IC"
     updateSinceUntilBuild false
     downloadSources true
     plugins "java", "Kotlin", "PythonCore:$python_core_version", "org.toml.lang:$toml_version"
-    alternativeIdePath "/opt/JetBrains/pycharm-community-2020.1" // PyCharmCommunity 2020.1 Path for runIde/debug
+    alternativeIdePath "/opt/JetBrains/pycharm-community-2020.1" // Change with the path to your IntelliJ CE installation directory
 
 }
 
@@ -39,24 +41,24 @@ allprojects {
 
     compileKotlin {
         kotlinOptions {
-            jvmTarget = "11"
-            languageVersion = "1.3"
-            apiVersion = "1.3"
+            jvmTarget = jvm_version
+            languageVersion = language_version
+            apiVersion = language_version
         }
     }
 
     compileTestKotlin {
         kotlinOptions {
-            jvmTarget = "11"
-            languageVersion = "1.3"
-            apiVersion = "1.3"
+            jvmTarget = jvm_version
+            languageVersion = language_version
+            apiVersion = language_version
         }
     }
 
     dependencies {
-        testCompile group: 'junit', name: 'junit', version: '4.13'
-        compile group: 'org.jetbrains', name: 'annotations', version: '20.0.0'
-        compile "org.apache.tuweni:tuweni-toml:1.0.0"
+        testImplementation 'junit:junit:4.13'
+        implementation "org.apache.tuweni:tuweni-toml:$tuweni_toml_version"
+        compile 'org.jetbrains:annotations:20.0.0'
     }
 
     jacocoTestReport {
@@ -66,10 +68,8 @@ allprojects {
         }
     }
 
-
-    sourceCompatibility = 11
-    targetCompatibility = 11
-
+    sourceCompatibility = jvm_version
+    targetCompatibility = jvm_version
 
 }
 

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -134,7 +134,7 @@
     <li>document</li>
     ]]></description>
 
-    <idea-version since-build="201.6668.115"/>
+    <idea-version since-build="201.*" until-build="202.*"/>
 
     <depends>com.intellij.modules.lang</depends>
     <depends>com.intellij.modules.python</depends>


### PR DESCRIPTION
- Centralised the dependency versions.
- Updated the following dependencies:
  - PythonCore@202.6397.124
  - Toml@0.2.128.3278-202
  - IntelliJ@2020.2
  - api@1.4
- Move dependencies to `Implementation` instead of `Compile`, as the latter is deprecated. (Didn't change `org.jetbrains:annotations` as it appears to not be compatible).