### PR TITLE
Add validation for poetry executable

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -1,9 +1,14 @@
 <idea-plugin url="https://github.com/koxudaxi/poetry-pycharm-plugin" require-restart="true">
     <id>com.koxudaxi.poetry</id>
     <name>Poetry</name>
-    <version>1.0.2</version>
+    <version>1.0.3</version>
     <vendor email="koaxudai@gmail.com">Koudai Aono @koxudaxi</vendor>
     <change-notes><![CDATA[
+    <h2>version 1.0.3</h2>
+    <p>Features</p>
+    <ul>
+        <li>Add validation for poetry executable [#165]</li>
+    </ul>
     <h2>version 1.0.2</h2>
     <p>Features</p>
     <ul>

--- a/src/com/koxudaxi/poetry/PyAddNewPoetryPanel.kt
+++ b/src/com/koxudaxi/poetry/PyAddNewPoetryPanel.kt
@@ -168,10 +168,15 @@ class PyAddNewPoetryPanel(private val project: Project?,
                 ?: return ValidationInfo("Poetry executable is not found")
         return when {
             !executable.exists() -> ValidationInfo(PyBundle.message("python.sdk.file.not.found", executable.absolutePath))
-            !Files.isExecutable(executable.toPath()) || !executable.isFile -> ValidationInfo(PyBundle.message("python.sdk.cannot.execute", executable.absolutePath))
+            !Files.isExecutable(executable.toPath()) || !executable.isFile || !testPoetryExecutable(executable) ->
+                ValidationInfo(PyBundle.message("python.sdk.cannot.execute", executable.absolutePath))
             else -> null
         }
     }
+
+    private fun testPoetryExecutable(executable: File): Boolean =
+        syncRunCommand(executable.parent, executable.absolutePath, "--help", defaultResult = false) { true }
+
 
     /**
      * Checks if the poetry for the project hasn't been already added.

--- a/src/com/koxudaxi/poetry/PyAddNewPoetryPanel.kt
+++ b/src/com/koxudaxi/poetry/PyAddNewPoetryPanel.kt
@@ -175,7 +175,7 @@ class PyAddNewPoetryPanel(private val project: Project?,
     }
 
     private fun testPoetryExecutable(executable: File): Boolean =
-        syncRunCommand(executable.parent, executable.absolutePath, "--help", defaultResult = false) { true }
+        syncRunCommand(executable.parent, executable.absolutePath, "--version", defaultResult = false) { true }
 
 
     /**


### PR DESCRIPTION
I add a validator that runs when selecting poetry executable in settings.
It calls `poetry --version`. And will check the return value of the command. 

## Related Issues
https://github.com/koxudaxi/poetry-pycharm-plugin/issues/162